### PR TITLE
Add feature for async_trait support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,11 @@ readme = "README.md"
 [lib]
 proc-macro = true
 
+[features]
+async_trait = []
+
 [dependencies]
 proc-macro2 = "1.0.6"
 syn = { version = "1.0.7", features = ["full"] }
 quote = "1.0.2"
+darling = "0.14.2"


### PR DESCRIPTION
This suggests adding a feature to ensure that the trait is generated with an async_trait invocation
* Feature `async_trait` disabled -> nothing changed
* Feature `async_trait` enabled -> by default, `#[async_trait]` will be added; can be disabled by using `#[extension_trait(async_trait = false)`]