### PR TITLE
Fix attribute handling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,7 @@ pub fn extension_trait(args: TokenStream, input: TokenStream) -> TokenStream {
             #visibility #unsafety trait #path {
                 #(#items)*
             }
+            #(#attrs)*
             #impl_item
         })
         .into()


### PR DESCRIPTION
This fixes the issue originally described in #9
Specifically, this patch enables doing things like this
```
#[extension_trait]
#[async_trait]
pub impl Hello for () {
    fn x(&self) -> i32 {
        42
    }
}

#[tokio::main]
async fn main() {
    println!("{}", ().x());
}
```

This may however lead to other problems in cases that were previously working, that is, if you want to apply an attribute that can only operate on trait definitions but not on impl items. In order to solve this, I would suggest to add parameters to the proc macro that control where attributes will be applied. This would furthermore enable doing stuff like e.g.
```
#[extension_trait(apply_attributes_to_impl)]
#[some_attribute]
pub impl Hello for () {
    fn x(&self) -> i32 {
        42
    }
}
```
which would expand to
```
pub trait Hello {
    fn x(&self) -> i32;
}
#[some_attribute]
impl Hello for () {
    fn x(&self) -> i32 {
        42
    }
}
```
Similarly, a flag `apply_attributes_to_definition` (naming is up to debate) could be used to ensure all attributes get added to the trait definition, and applying both flags would result in the behavior currently implemented in this PR. One remaining open question about this would be the desired default, which I personally would find most intuitive to be either both or none enabled. But for backwards compatibility, it may make sense to only enable `apply_attributes_to_definition` by default.
What do you think about this solution? If you do like this proposal, I'd be happy to continue to implement it :)